### PR TITLE
JmhPlugin off except when enabled

### DIFF
--- a/src/main/scala/pl/project13/scala/sbt/JmhPlugin.scala
+++ b/src/main/scala/pl/project13/scala/sbt/JmhPlugin.scala
@@ -29,8 +29,8 @@ object JmhPlugin extends AutoPlugin {
   /** All we need is Java. */
   override def requires = plugins.JvmPlugin
 
-  /** This enables the plugin once all requirements are fulfilled. */
-  override def trigger = allRequirements
+  /** Plugin must be enabled on the benchmarks project. See http://www.scala-sbt.org/0.13/tutorial/Using-Plugins.html */
+  override def trigger = noTrigger
 
   override def projectSettings = Seq(
     sourceGenerators in Jmh := (sourceGenerators in Compile).value,


### PR DESCRIPTION
When JmhPlugin is on all project by default, it inserts an undesirable `jmh:compile` dependency on each project's `run`.
E.g. 

```
sbt (spandex)> inspect spandex-http/run
[info] Input task: Unit
[info] Description:
[info]  Runs a main class, passing along arguments provided on the command line.
[info] Provided by:
[info]  {file:/usr/local/src/socrata/spandex/}spandex-http/compile:run
[info] Defined at:
[info]  (sbt.Defaults) Defaults.scala:762
[info]  (pl.project13.scala.sbt.JmhPlugin) JmhPlugin.scala:83
[info] Dependencies:
[info]  spandex-http/compile:run::runner
[info]  spandex-http/compile:run::streams
[info]  spandex-http/jmh:compile
[info]  spandex-http/runtime:fullClasspath
[info]  spandex-http/compile:run::mainClass
...
```

Disabling is one call `.disablePlugins(JmhPlugin)` on each other project. Enabling on the one (or each) performance benchmarking project is just one addition to the build project: `.enablePlugins(JmhPlugin)`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sokrahta/sbt-jmh/1)

<!-- Reviewable:end -->
